### PR TITLE
Drop official support for PyPy

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, '3.x', 'pypy3']
+        python-version: [3.6, 3.7, 3.8, '3.x']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
[PyPy](https://www.pypy.org/) tests take too long (currently ~40 min) and are probably unnecessary, as long as we ensure support for 3.x. Specifically, I don't see any reason to keep with this. With that being said, we can infer compatibility with PyPy and give up on testing for it.