### PR TITLE
Do not test on macOS anymore, only on Ubuntu/Linux

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os:
+          - ubuntu-latest
+          # - windows-latest
+          # - macos-latest
         python-version: [ 3.6, '3.x' ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Testing on macOS is too expensive (10x as much as on Linux). Our tests so far run well on macOS, so we can infer compatibility (Python is cross-platform anyway).

~Windows is more affordable (2x as much), so let's test on it instead.~

Windows throws *a lot* of weird errors, mostly related to Unicode and file paths. It is not worth it at this point, so that I will stick with Linux.