### PR TITLE
Be less strict with negative moments of inertia

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Lint with Ruff
         run: |
-          poetry run ruff . --show-source
+          ruff check --output-format=github .
 
       - name: Lint with Black
         uses: psf/black@stable

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,8 @@ jobs:
           poetry install --extras "cli fast solvents"
 
       - name: Lint with Ruff
-      - uses: astral-sh/ruff-action@v1
+      - run: |
+          poetry run ruff check --output-format=github .
 
       - name: Lint with Black
         uses: psf/black@stable

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,8 +40,7 @@ jobs:
           poetry install --extras "cli fast solvents"
 
       - name: Lint with Ruff
-        run: |
-          ruff check --output-format=github .
+      - uses: astral-sh/ruff-action@v1
 
       - name: Lint with Black
         uses: psf/black@stable

--- a/overreact/coords.py
+++ b/overreact/coords.py
@@ -2011,7 +2011,7 @@ def _equivalent_atoms(
         Atomic coordinates.
     method : str, optional
         Method of partitioning: "atommass" (same atoms same groups), "cluster".
-    thresh : int, optional
+    thresh : float, optional
         Threshold to consider atom clusters.
 
     Returns

--- a/overreact/thermo/_gas.py
+++ b/overreact/thermo/_gas.py
@@ -33,7 +33,6 @@ def calc_trans_energy(temperature=298.15):
     3718.
     >>> calc_trans_energy(373.15)
     4653.
-
     """
     temperature = np.asarray(temperature)
 
@@ -95,7 +94,6 @@ def calc_elec_energy(energy=0.0, degeneracy=1, temperature=298.15):
     ...     energy * 100 * constants.h * constants.c * constants.N_A, degeneracy
     ... )
     321.00
-
     """
     temperature = np.asarray(temperature)
 
@@ -172,7 +170,6 @@ def calc_elec_entropy(energy=0.0, degeneracy=1, temperature=298.15):
     >>> calc_elec_entropy(energy * 100 * constants.h * constants.c * constants.N_A,
     ...                   degeneracy)
     13.175
-
     """
     temperature = np.asarray(temperature)
 
@@ -243,7 +240,6 @@ def calc_rot_energy(
 
     >>> calc_rot_energy()
     0.0
-
     """
     temperature = np.asarray(temperature)
 
@@ -492,7 +488,6 @@ def calc_vib_energy(vibfreqs=None, qrrho=True, temperature=298.15):
 
     >>> calc_vib_energy()
     0.0
-
     """
     vibrational_temperature = _vibrational_temperature(vibfreqs)
     if not vibrational_temperature.size:
@@ -573,7 +568,6 @@ def calc_vib_entropy(vibfreqs=None, qrrho=True, temperature=298.15):
 
     >>> calc_vib_entropy()
     0.0
-
     """
     if np.isclose(temperature, 0.0):
         logger.warning("assuming vibrational entropy zero at zero temperature")

--- a/overreact/thermo/_gas.py
+++ b/overreact/thermo/_gas.py
@@ -644,7 +644,9 @@ def _sackur_tetrode(atommasses, volume, temperature=298.15):
     return constants.R * (np.log(q_trans) + 2.5)
 
 
-def _rotational_temperature(moments=None, thresh=1e-63):
+# NOTE(schneiderfelipe): thresh was found to be reasonable
+# when greater than or equal to 3e-47.
+def _rotational_temperature(moments=None, thresh=3e-47):
     """Calculate rotational temperatures.
 
     This function returns rotational temperatures associated with all non-zero
@@ -680,6 +682,13 @@ def _rotational_temperature(moments=None, thresh=1e-63):
     array([81.88521438, 81.88521438])
     >>> _rotational_temperature([i, i, i])
     array([81.88521438, 81.88521438, 81.88521438])
+
+    Small values are considered zero with comparison to thresh:
+
+    >>> z = -2.18952885e-47
+    >>> j = 1.15909934e+01
+    >>> _rotational_temperature([z, j, j])
+    array([2.09251841e+00,  2.09251841e+00])
     """
     if moments is None:
         # assuming atomic system

--- a/overreact/thermo/_gas.py
+++ b/overreact/thermo/_gas.py
@@ -644,7 +644,7 @@ def _sackur_tetrode(atommasses, volume, temperature=298.15):
     return constants.R * (np.log(q_trans) + 2.5)
 
 
-def _rotational_temperature(moments=None):
+def _rotational_temperature(moments=None, thresh=1e-63):
     """Calculate rotational temperatures.
 
     This function returns rotational temperatures associated with all non-zero
@@ -654,6 +654,8 @@ def _rotational_temperature(moments=None):
     ----------
     moments : array-like
         Primary moments of inertia in ascending order. Units are in amu·Å².
+    thresh : float, optional
+        Threshold to consider small moments of inertia equal to zero.
 
     Returns
     -------
@@ -683,7 +685,7 @@ def _rotational_temperature(moments=None):
         # assuming atomic system
         return np.array([])
     moments = np.atleast_1d(moments)
-    moments[np.abs(moments) < 1e-63] = 0  # set almost zeros to exact zeros
+    moments[np.abs(moments) < thresh] = 0  # set almost zeros to exact zeros
     moments = (
         moments[np.nonzero(moments)] * constants.atomic_mass * constants.angstrom**2
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ requires = ["poetry-core>=1.0.0"]
 
 [tool.ruff]
 target-version = "py38"
+
+[tool.ruff.lint]
 select = ["ALL"]
 # TODO(schneiderfelipe): make this list shorter
 ignore = [
@@ -144,7 +146,7 @@ ignore = [
   "TD003",
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.coverage.run]


### PR DESCRIPTION
It turns out zeroing moments of inertia whose absolute value were less than $10^{-63}$ let some real world cases slip, which led to negative rotational temperatures and some `NaN` sadness.

This PR
- tests this particular case (as a doctest)
- fixes this particular case
- allows selecting a different threshold for the internal function `_rotational_temperature`
- EDIT: also fixes CI