### PR TITLE
fix: jax config not found

### DIFF
--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 if _found_jax:
     import jax.numpy as jnp
     from jax import jacfwd, jit
-    from jax.config import config
+    from jax import config
 
     config.update("jax_enable_x64", True)
 else:


### PR DESCRIPTION
[jax.config was depracated, and the recommended way now](https://github.com/jax-ml/jax/discussions/18403#discussioncomment-7488528) is to import the config like so: `from jax import config`.

This PR adresses this update.
