### PR TITLE
Diffrax integration

### DIFF
--- a/overreact/_cli.py
+++ b/overreact/_cli.py
@@ -856,17 +856,7 @@ def main(arguments=None):
             "integrator used in solving the ODE system of the microkinetic "
             "simulation (Kvaerno methods require overreact[fast])"
         ),
-        choices=[
-            "RK23",
-            "DOP853",
-            "RK45",
-            "LSODA",
-            "BDF",
-            "Radau",
-            "Kvaerno3",
-            "Kvaerno4",
-            "Kvaerno5",
-        ],
+        choices=rx.simulate.SUPPORTED_SOLVERS,
         default="RK23",
     )
     parser.add_argument(

--- a/overreact/_cli.py
+++ b/overreact/_cli.py
@@ -852,8 +852,21 @@ def main(arguments=None):
     )
     parser.add_argument(
         "--method",
-        help="integrator used in solving the ODE system of the microkinetic simulation",
-        choices=["RK23", "DOP853", "RK45", "LSODA", "BDF", "Radau"],
+        help=(
+            "integrator used in solving the ODE system of the microkinetic "
+            "simulation (Kvaerno methods require overreact[fast])"
+        ),
+        choices=[
+            "RK23",
+            "DOP853",
+            "RK45",
+            "LSODA",
+            "BDF",
+            "Radau",
+            "Kvaerno3",
+            "Kvaerno4",
+            "Kvaerno5",
+        ],
         default="RK23",
     )
     parser.add_argument(

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -197,7 +197,7 @@ def get_y(
 
         jac = None
         if hasattr(dydt, "jac"):
-            jac = dydt.jac  # noqa: F841
+            jac = dydt.jac
 
         logger.warning(f"@t = \x1b[94m{0:10.3f} \x1b[ms\x1b[K")
         res = solve_ivp(
@@ -210,7 +210,7 @@ def get_y(
             first_step=first_step,
             rtol=rtol,
             atol=atol,
-            # jac=jac,  # noqa: ERA001
+            jac=jac,
         )
         logger.warning(res)
         y = res.sol
@@ -355,7 +355,7 @@ def get_dydt(scheme, k, ef=EF):
 
     def _dydt(_t, y):
         # Avoid differentiating 0**0 for compounds that do not participate in
-        # a reaction, this causes NaN fileed jacobians in diffrax otherwise.
+        # a reaction, this causes NaN filled jacobians in jax otherwise.
         bases = jnp.where(M == 0, 1.0, y)
         r = k_adj * jnp.prod(jnp.power(bases, M), axis=1)
         return jnp.dot(A, r)

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -112,7 +112,7 @@ def get_y(
     Notes
     -----
     Diffrax's implicit Kvaerno solvers use adaptive step sizes controlled by
-    ``rtol`` and ``atol``. 
+    ``rtol`` and ``atol``.
 
     Examples
     --------
@@ -331,7 +331,10 @@ def get_dydt(scheme, k, ef=EF):
     k_adj = _adjust_k(scheme, k, ef=ef)
 
     def _dydt(_t, y):
-        r = k_adj * jnp.prod(jnp.power(y, M), axis=1)
+        # Avoid differentiating 0**0 for compounds that do not participate in
+        # a reaction, this causes NaN fileed jacobians in diffrax otherwise.
+        bases = jnp.where(M == 0, 1.0, y)
+        r = k_adj * jnp.prod(jnp.power(bases, M), axis=1)
         return jnp.dot(A, r)
 
     if _found_jax:

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -179,10 +179,6 @@ def get_y(
     max_step = np.min([max_step, (t_span[1] - t_span[0]) / 2.0])
     logger.warning(f"max step = {max_step} s")
 
-    if first_step is not None:
-        first_step = np.min([first_step, max_step / 2.0])
-    logger.warning(f"first step = {first_step} s")
-
     if method in _DIFFRAX_SOLVERS:
         y = _get_y_diffrax(
             dydt,
@@ -196,7 +192,8 @@ def get_y(
         )
     else:
         if first_step is None:
-            first_step = np.finfo(np.float64).eps
+            first_step = np.min([np.finfo(np.float64).eps, max_step / 2.0])
+        logger.warning(f"first step = {first_step} s")
 
         jac = None
         if hasattr(dydt, "jac"):
@@ -243,6 +240,11 @@ def _get_y_diffrax(dydt, y0, t_span, method, max_step, first_step, rtol, atol):
             f"{', '.join(_SCIPY_SOLVERS)}"
         )
         raise ImportError(msg) from exc
+
+    if first_step is not None:
+        logger.warning(f"first step = {first_step} s")
+    else:
+        logger.warning("no first step given, diffrax will choose automatically")
 
     solver = {
         "Kvaerno3": diffrax.Kvaerno3,

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -34,7 +34,17 @@ from overreact._misc import _found_jax
 # TODO(schneiderfelipe): this should probably be exposed to the user and use the actual simulation temperature.
 EF = np.exp(1.25 * constants.kcal / (constants.R * 298.15))
 
-_DIFFRAX_METHODS = ("Kvaerno3", "Kvaerno4", "Kvaerno5")
+_SCIPY_SOLVERS = (
+    "RK23",
+    "DOP853",
+    "RK45",
+    "LSODA",
+    "BDF",
+    "Radau",
+)
+_DIFFRAX_SOLVERS = ("Kvaerno3", "Kvaerno4", "Kvaerno5")
+
+SUPPORTED_SOLVERS = _SCIPY_SOLVERS + _DIFFRAX_SOLVERS
 
 
 logger = logging.getLogger(__name__)
@@ -173,7 +183,7 @@ def get_y(
         first_step = np.min([first_step, max_step / 2.0])
     logger.warning(f"first step = {first_step} s")
 
-    if method in _DIFFRAX_METHODS:
+    if method in _DIFFRAX_SOLVERS:
         y = _get_y_diffrax(
             dydt,
             y0,
@@ -229,6 +239,8 @@ def _get_y_diffrax(dydt, y0, t_span, method, max_step, first_step, rtol, atol):
         msg = (
             f"the {method} solver requires Diffrax; "
             'install it with `pip install "overreact[fast]"`'
+            "or choose one of the following solvers: "
+            f"{', '.join(_SCIPY_SOLVERS)}"
         )
         raise ImportError(msg) from exc
 

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -34,6 +34,8 @@ from overreact._misc import _found_jax
 # TODO(schneiderfelipe): this should probably be exposed to the user and use the actual simulation temperature.
 EF = np.exp(1.25 * constants.kcal / (constants.R * 298.15))
 
+_DIFFRAX_METHODS = ("Kvaerno3", "Kvaerno4", "Kvaerno5")
+
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +60,7 @@ def get_y(
     t_span=None,
     method="RK23",
     max_step=np.inf,
-    first_step=np.finfo(np.float64).eps,
+    first_step=None,
     rtol=1e-3,
     atol=1e-6,
     max_time=1 * 60 * 60,
@@ -89,9 +91,9 @@ def get_y(
         Maximum step to be performed by the integrator.
         Defaults to half the total time span.
     first_step : float, optional
-        First step size.
-        Defaults to half the maximum step, or `np.finfo(np.float64).eps`,
-        whichever is smallest.
+        First step size. If not given, Diffrax chooses one automatically,
+        while the SciPy backend uses `np.finfo(np.float64).eps` for backwards
+        compatibility.
     rtol, atol : array-like, optional
         See `scipy.integrate.solve_ivp` for details.
     max_time : float, optional
@@ -160,28 +162,44 @@ def get_y(
     max_step = np.min([max_step, (t_span[1] - t_span[0]) / 2.0])
     logger.warning(f"max step = {max_step} s")
 
-    first_step = np.min([first_step, max_step / 2.0])
+    if first_step is not None:
+        first_step = np.min([first_step, max_step / 2.0])
     logger.warning(f"first step = {first_step} s")
 
-    jac = None
-    if hasattr(dydt, "jac"):
-        jac = dydt.jac  # noqa: F841
+    if method in _DIFFRAX_METHODS:
+        y = _get_y_diffrax(
+            dydt,
+            y0,
+            t_span,
+            method,
+            max_step,
+            first_step,
+            rtol,
+            atol,
+        )
+    else:
+        if first_step is None:
+            first_step = np.finfo(np.float64).eps
 
-    logger.warning(f"@t = \x1b[94m{0:10.3f} \x1b[ms\x1b[K")
-    res = solve_ivp(
-        dydt,
-        t_span,
-        y0,
-        method=method,
-        dense_output=True,
-        max_step=max_step,
-        first_step=first_step,
-        rtol=rtol,
-        atol=atol,
-        # jac=jac,  # noqa: ERA001
-    )
-    logger.warning(res)
-    y = res.sol
+        jac = None
+        if hasattr(dydt, "jac"):
+            jac = dydt.jac  # noqa: F841
+
+        logger.warning(f"@t = \x1b[94m{0:10.3f} \x1b[ms\x1b[K")
+        res = solve_ivp(
+            dydt,
+            t_span,
+            y0,
+            method=method,
+            dense_output=True,
+            max_step=max_step,
+            first_step=first_step,
+            rtol=rtol,
+            atol=atol,
+            # jac=jac,  # noqa: ERA001
+        )
+        logger.warning(res)
+        y = res.sol
 
     def r(t):
         # TODO(schneiderfelipe): this is probably not the best way to
@@ -192,6 +210,52 @@ def get_y(
             return dydt(t, y(t))
 
     return y, r
+
+
+def _get_y_diffrax(dydt, y0, t_span, method, max_step, first_step, rtol, atol):
+    """Solve an initial value problem with a Diffrax stiff solver."""
+    try:
+        import diffrax
+        import jax
+        import jax.numpy as jnp
+    except ImportError as exc:
+        msg = (
+            f"the {method} solver requires Diffrax; "
+            'install it with `pip install "overreact[fast]"`'
+        )
+        raise ImportError(msg) from exc
+
+    solver = {
+        "Kvaerno3": diffrax.Kvaerno3,
+        "Kvaerno4": diffrax.Kvaerno4,
+        "Kvaerno5": diffrax.Kvaerno5,
+    }[method]()
+    term = diffrax.ODETerm(lambda t, y, _args: dydt(t, y))
+    stepsize_controller = diffrax.PIDController(
+        rtol=rtol,
+        atol=atol,
+        dtmax=max_step,
+    )
+    solution = diffrax.diffeqsolve(
+        term,
+        solver,
+        t0=t_span[0],
+        t1=t_span[1],
+        dt0=first_step,
+        y0=jnp.asarray(y0),
+        saveat=diffrax.SaveAt(dense=True),
+        stepsize_controller=stepsize_controller,
+    )
+
+    def y(t):
+        if np.ndim(t) == 0:
+            return np.asarray(solution.evaluate(t))
+        values = jax.vmap(solution.evaluate)(jnp.asarray(t))
+        return np.asarray(values).T
+
+    y.t_min = float(solution.t0)
+    y.t_max = float(solution.t1)
+    return y
 
 
 def get_dydt(scheme, k, ef=EF):

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -226,7 +226,16 @@ def get_y(
     return y, r
 
 
-def _get_y_diffrax(dydt, y0, t_span, method, max_step, first_step, rtol, atol):
+def _get_y_diffrax(
+    dydt,
+    y0,
+    t_span,
+    method="Kvaerno3",
+    max_step=np.inf,
+    first_step=None,
+    rtol=1e-3,
+    atol=1e-6,
+):
     """Solve an initial value problem with a Diffrax stiff solver."""
     try:
         import diffrax

--- a/overreact/simulate.py
+++ b/overreact/simulate.py
@@ -69,8 +69,8 @@ def get_y(
 
     This function provides two functions that calculate the concentrations and
     the rates of formation at any point in time for any compound. It does that
-    by solving an initial value problem (IVP) through scipy's ``solve_ivp``
-    under the hood.
+    by solving an initial value problem (IVP) through scipy's ``solve_ivp`` or
+    Diffrax's ``diffeqsolve`` under the hood.
 
     Parameters
     ----------
@@ -84,9 +84,12 @@ def get_y(
         is chosen based on the system at hand (the method of choice works for
         any zeroth-, first- or second-order reactions).
     method : str, optional
-        Integration method to use. See `scipy.integrate.solve_ivp` for details.
-        Kinetics problems are very often stiff and, as such, "RK23" and "RK45" may be
-        unsuited. "LSODA", "BDF", and "Radau" are worth a try if things go bad.
+        Integration method to use. All existing methods are
+        provided by `scipy.integrate.solve_ivp`, except for "Kvaerno3",
+        "Kvaerno4", and "Kvaerno5", which use Diffrax instead.
+        Kinetics problems are very often stiff and, as such,
+        "RK23" and "RK45" may be unsuited. "LSODA", "BDF", "Radau", and the
+        Kvaerno methods are worth trying for stiff systems.
     max_step : float, optional
         Maximum step to be performed by the integrator.
         Defaults to half the total time span.
@@ -104,8 +107,12 @@ def get_y(
     -------
     y, r : callable
         Concentrations and reaction rates as functions of time. The y object
-        is an OdeSolution and stores attributes t_min and t_max.
+        stores attributes t_min and t_max.
 
+    Notes
+    -----
+    Diffrax's implicit Kvaerno solvers use adaptive step sizes controlled by
+    ``rtol`` and ``atol``. 
 
     Examples
     --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,6 @@ dependencies = [
 cli = ["rich>=13,<16"]
 fast = [
     "diffrax>=0.7,<0.8",
-    "jax>=0.4",
-    "jaxlib>=0.4",
 ]
 solvents = ["thermo>=0.2"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["rich>=13,<15"]
 fast = [
+    "diffrax>=0.7,<0.8",
     "jax>=0.4",
     "jaxlib>=0.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["rich>=13,<16"]
 fast = [
+    "diffrax>=0.7,<0.8",
     "jax>=0.4",
     "jaxlib>=0.4",
 ]

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -118,7 +118,7 @@ def test_get_y_conservation_in_equilibria() -> None:
         for sub0 in [0.01, 0.02]
         for keq in [1.0, 10.0, 100.0]
         for kcat in [1e-1, 1e1, 1e10, 1e11, 1e13]
-        for method in ("RK23", "LSODA", "Radau", "BDF")
+        for method in ("RK23", "LSODA", "Radau", "BDF", "Kvaerno5")
     ],
 )
 def test_simple_michaelis_menten(
@@ -166,7 +166,7 @@ CS -> TS‡ -> C + P  // Catalyst is released
         for sub0 in [0.01, 0.02]
         for keq in [1.0, 10.0, 100.0]
         for kcat in [1e-1, 1e1, 1e10, 1e11, 1e13]
-        for method in ("RK23", "LSODA", "Radau", "BDF")
+        for method in ("RK23", "LSODA", "Radau", "BDF", "Kvaerno5")
     ],
 )
 def test_consuming_michaelis_menten(

--- a/uv.lock
+++ b/uv.lock
@@ -624,12 +624,45 @@ wheels = [
 ]
 
 [[package]]
+name = "diffrax"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "lineax" },
+    { name = "optimistix" },
+    { name = "typing-extensions" },
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/ea/a22853377a840d70d1d174d43183f12990c66eecf34ba7e76eec781249d0/diffrax-0.7.2.tar.gz", hash = "sha256:9adc70fe90dba83f7dd839845839b2531a3dd736a3944fe1aa26598507cfb48e", size = 155159, upload-time = "2026-02-18T01:14:04.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/48/c42f657f3d6b4d9d9674c9bc48e763d024511ea4cc1d6e0c68c7b4380c43/diffrax-0.7.2-py3-none-any.whl", hash = "sha256:1beee2f991cd049962fe3c89da28f933753aa66d80bef857533276c9f23301ed", size = 199673, upload-time = "2026-02-18T01:14:03.38Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "equinox"
+version = "0.13.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "typing-extensions" },
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ff/522336d2f8264f2ad97119710b76e2cddf66145d03a1e89899175d26b192/equinox-0.13.8.tar.gz", hash = "sha256:dd075050018e2dd02e252e9d29d3060f7e67f085622d8d27a8e89e24bb8523db", size = 145257, upload-time = "2026-05-05T10:03:43.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/d6/69a76c8ccdef14af687c497040292a46e59fc7a0ab24724b60e50ca61030/equinox-0.13.8-py3-none-any.whl", hash = "sha256:ca004348533cc30a63ebe8823d7dd4bb626dce17743d40bbddb89b402ef2a240", size = 185813, upload-time = "2026-05-05T10:03:41.673Z" },
 ]
 
 [[package]]
@@ -921,6 +954,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/c9/5653eb4be25a3235be2606e1e8fb28fb8c6f0f48b33b947e47f0dc7e7ec0/jaxlib-0.9.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b8998f9fa6e67bf956044c310023f6a7bbfaa0d8955f11d928404c8f6eb02fcf", size = 58882789, upload-time = "2026-03-18T23:28:00.834Z" },
     { url = "https://files.pythonhosted.org/packages/41/8d/ef12f6a2f158d47480cded343c85078a02e9fc7d4952dafcd95dab6f9127/jaxlib-0.9.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:35b473df72dbc2cfda0cb1b3de7521a2150a0aa5ef57ed7583eeceb012dc17c0", size = 77850880, upload-time = "2026-03-18T23:28:04.063Z" },
     { url = "https://files.pythonhosted.org/packages/c9/6a/6dff1e6e3f9d918bc777e087091bdefbd7d33328c1d1b152429c6cdcf723/jaxlib-0.9.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:bbe59bdef668ff5fd998c6d88e8df9a32ab95bec0dea3d2b5f7a11b86a9a6788", size = 83425685, upload-time = "2026-03-18T23:28:07.906Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/c1/091b8852bd7cbf50bd655543c8506033cf4029300c67f8c176c1286879a9/jaxtyping-0.3.11.tar.gz", hash = "sha256:b09c14acf6686feb9e0df5b0d8c6e7c5b6f8d36bf059ee54cd522a186c2ef050", size = 46489, upload-time = "2026-06-13T18:35:23.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/38/c66bbdc5047f4776c2bd3e47e5295a350e3fa44d5b8942105e71c2a876a0/jaxtyping-0.3.11-py3-none-any.whl", hash = "sha256:8a4bedc4e3f963fa82df41bd13c7ebc2bad925601eb48614c65798f21329d4e3", size = 56593, upload-time = "2026-06-13T18:35:22.01Z" },
 ]
 
 [[package]]
@@ -1318,6 +1363,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "lineax"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/d6/4e28416a6fe58dd6bc7565b1ffa330f4d0ba7d74212642b1b734c511299e/lineax-0.1.0.tar.gz", hash = "sha256:5f1a8f060142af2cdbf7d66b99e8d3071c3aa734b677df6339df4b4c4c0554d2", size = 50209, upload-time = "2026-01-27T21:17:26.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/0c/2ed47112fc1958a0a81c9b015d4e1861953a1ec3a17b081c0180a25ce82c/lineax-0.1.0-py3-none-any.whl", hash = "sha256:f00911c6b07d427c4835db46856970c8348bc82a035b51f4386ad09382af957a", size = 74600, upload-time = "2026-01-27T21:17:25.33Z" },
 ]
 
 [[package]]
@@ -1771,6 +1831,22 @@ wheels = [
 ]
 
 [[package]]
+name = "optimistix"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "lineax" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/0b/3bdc0e698cb0d264e5dca0b5bb171342a950a43fa6e046d8c57189298422/optimistix-0.1.0.tar.gz", hash = "sha256:f05c9104748e87e1dc10a0b4a2be94e427f98c3eab0b1d41ea24a593d76be03d", size = 70164, upload-time = "2026-02-16T13:35:43.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/53/6a81a6ebb1739f19c32002139719d4ee021a349d5bdbe066910feed327a1/optimistix-0.1.0-py3-none-any.whl", hash = "sha256:c8edda7bf7fe48839c93fcd72bce750c950ed9f7033158303150b7ab395add81", size = 101740, upload-time = "2026-02-16T13:35:42.971Z" },
+]
+
+[[package]]
 name = "overreact"
 version = "1.2.0"
 source = { editable = "." }
@@ -1785,6 +1861,7 @@ cli = [
     { name = "rich" },
 ]
 fast = [
+    { name = "diffrax" },
     { name = "jax" },
     { name = "jaxlib" },
 ]
@@ -1814,6 +1891,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cclib", specifier = ">=1,<2" },
+    { name = "diffrax", marker = "extra == 'fast'", specifier = ">=0.7,<0.8" },
     { name = "importlib", specifier = ">=1.0.4,<2" },
     { name = "jax", marker = "extra == 'fast'", specifier = ">=0.4" },
     { name = "jaxlib", marker = "extra == 'fast'", specifier = ">=0.4" },
@@ -2905,6 +2983,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1862,8 +1862,6 @@ cli = [
 ]
 fast = [
     { name = "diffrax" },
-    { name = "jax" },
-    { name = "jaxlib" },
 ]
 solvents = [
     { name = "thermo" },
@@ -1893,9 +1891,7 @@ requires-dist = [
     { name = "cclib", specifier = ">=1,<2" },
     { name = "diffrax", marker = "extra == 'fast'", specifier = ">=0.7,<0.8" },
     { name = "importlib", specifier = ">=1.0.4,<2" },
-    { name = "jax", marker = "extra == 'fast'", specifier = ">=0.4" },
-    { name = "jaxlib", marker = "extra == 'fast'", specifier = ">=0.4" },
-    { name = "rich", marker = "extra == 'cli'", specifier = ">=13,<15" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=13,<16" },
     { name = "scipy", specifier = ">=1.10,<2" },
     { name = "thermo", marker = "extra == 'solvents'", specifier = ">=0.2" },
 ]
@@ -1905,19 +1901,19 @@ provides-extras = ["cli", "fast", "solvents"]
 dev = [
     { name = "debugpy", specifier = ">=1,<2" },
     { name = "flynt", specifier = ">=0.77,<1.1" },
-    { name = "ipython", specifier = ">=8,<9" },
+    { name = "ipython", specifier = ">=8,<10" },
     { name = "jupyter", specifier = ">=1.0.0,<2" },
     { name = "matplotlib", specifier = ">=3,<4" },
     { name = "mypy", specifier = ">=0.991,<2.4" },
-    { name = "pdoc", specifier = ">=12,<15" },
+    { name = "pdoc", specifier = ">=12,<17" },
     { name = "perflint", specifier = ">=0.7.1,<0.9.0" },
     { name = "pytest", specifier = ">=7.2,<10.0" },
-    { name = "pytest-cov", specifier = ">=4,<6" },
-    { name = "rich", specifier = ">=13,<15" },
-    { name = "ruff", specifier = ">=0.0.210,<0.16.3" },
+    { name = "pytest-cov", specifier = ">=4,<8" },
+    { name = "rich", specifier = ">=13,<16" },
+    { name = "ruff", specifier = ">=0.0.210,<0.16.5" },
     { name = "seaborn", specifier = ">=0.12,<0.14" },
     { name = "thermo", specifier = ">=0.2" },
-    { name = "types-setuptools", specifier = ">=65,<84" },
+    { name = "types-setuptools", specifier = ">=65,<85" },
 ]
 
 [[package]]
@@ -2059,7 +2055,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -624,12 +624,45 @@ wheels = [
 ]
 
 [[package]]
+name = "diffrax"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "lineax" },
+    { name = "optimistix" },
+    { name = "typing-extensions" },
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/ea/a22853377a840d70d1d174d43183f12990c66eecf34ba7e76eec781249d0/diffrax-0.7.2.tar.gz", hash = "sha256:9adc70fe90dba83f7dd839845839b2531a3dd736a3944fe1aa26598507cfb48e", size = 155159, upload-time = "2026-02-18T01:14:04.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/48/c42f657f3d6b4d9d9674c9bc48e763d024511ea4cc1d6e0c68c7b4380c43/diffrax-0.7.2-py3-none-any.whl", hash = "sha256:1beee2f991cd049962fe3c89da28f933753aa66d80bef857533276c9f23301ed", size = 199673, upload-time = "2026-02-18T01:14:03.38Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "equinox"
+version = "0.13.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "typing-extensions" },
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ff/522336d2f8264f2ad97119710b76e2cddf66145d03a1e89899175d26b192/equinox-0.13.8.tar.gz", hash = "sha256:dd075050018e2dd02e252e9d29d3060f7e67f085622d8d27a8e89e24bb8523db", size = 145257, upload-time = "2026-05-05T10:03:43.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/d6/69a76c8ccdef14af687c497040292a46e59fc7a0ab24724b60e50ca61030/equinox-0.13.8-py3-none-any.whl", hash = "sha256:ca004348533cc30a63ebe8823d7dd4bb626dce17743d40bbddb89b402ef2a240", size = 185813, upload-time = "2026-05-05T10:03:41.673Z" },
 ]
 
 [[package]]
@@ -921,6 +954,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/c9/5653eb4be25a3235be2606e1e8fb28fb8c6f0f48b33b947e47f0dc7e7ec0/jaxlib-0.9.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b8998f9fa6e67bf956044c310023f6a7bbfaa0d8955f11d928404c8f6eb02fcf", size = 58882789, upload-time = "2026-03-18T23:28:00.834Z" },
     { url = "https://files.pythonhosted.org/packages/41/8d/ef12f6a2f158d47480cded343c85078a02e9fc7d4952dafcd95dab6f9127/jaxlib-0.9.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:35b473df72dbc2cfda0cb1b3de7521a2150a0aa5ef57ed7583eeceb012dc17c0", size = 77850880, upload-time = "2026-03-18T23:28:04.063Z" },
     { url = "https://files.pythonhosted.org/packages/c9/6a/6dff1e6e3f9d918bc777e087091bdefbd7d33328c1d1b152429c6cdcf723/jaxlib-0.9.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:bbe59bdef668ff5fd998c6d88e8df9a32ab95bec0dea3d2b5f7a11b86a9a6788", size = 83425685, upload-time = "2026-03-18T23:28:07.906Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/c1/091b8852bd7cbf50bd655543c8506033cf4029300c67f8c176c1286879a9/jaxtyping-0.3.11.tar.gz", hash = "sha256:b09c14acf6686feb9e0df5b0d8c6e7c5b6f8d36bf059ee54cd522a186c2ef050", size = 46489, upload-time = "2026-06-13T18:35:23.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/38/c66bbdc5047f4776c2bd3e47e5295a350e3fa44d5b8942105e71c2a876a0/jaxtyping-0.3.11-py3-none-any.whl", hash = "sha256:8a4bedc4e3f963fa82df41bd13c7ebc2bad925601eb48614c65798f21329d4e3", size = 56593, upload-time = "2026-06-13T18:35:22.01Z" },
 ]
 
 [[package]]
@@ -1317,6 +1362,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "lineax"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/d6/4e28416a6fe58dd6bc7565b1ffa330f4d0ba7d74212642b1b734c511299e/lineax-0.1.0.tar.gz", hash = "sha256:5f1a8f060142af2cdbf7d66b99e8d3071c3aa734b677df6339df4b4c4c0554d2", size = 50209, upload-time = "2026-01-27T21:17:26.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/0c/2ed47112fc1958a0a81c9b015d4e1861953a1ec3a17b081c0180a25ce82c/lineax-0.1.0-py3-none-any.whl", hash = "sha256:f00911c6b07d427c4835db46856970c8348bc82a035b51f4386ad09382af957a", size = 74600, upload-time = "2026-01-27T21:17:25.33Z" },
 ]
 
 [[package]]
@@ -1770,6 +1830,22 @@ wheels = [
 ]
 
 [[package]]
+name = "optimistix"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "lineax" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/0b/3bdc0e698cb0d264e5dca0b5bb171342a950a43fa6e046d8c57189298422/optimistix-0.1.0.tar.gz", hash = "sha256:f05c9104748e87e1dc10a0b4a2be94e427f98c3eab0b1d41ea24a593d76be03d", size = 70164, upload-time = "2026-02-16T13:35:43.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/53/6a81a6ebb1739f19c32002139719d4ee021a349d5bdbe066910feed327a1/optimistix-0.1.0-py3-none-any.whl", hash = "sha256:c8edda7bf7fe48839c93fcd72bce750c950ed9f7033158303150b7ab395add81", size = 101740, upload-time = "2026-02-16T13:35:42.971Z" },
+]
+
+[[package]]
 name = "overreact"
 version = "1.2.0"
 source = { editable = "." }
@@ -1784,6 +1860,7 @@ cli = [
     { name = "rich" },
 ]
 fast = [
+    { name = "diffrax" },
     { name = "jax" },
     { name = "jaxlib" },
 ]
@@ -1813,6 +1890,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cclib", specifier = ">=1,<2" },
+    { name = "diffrax", marker = "extra == 'fast'", specifier = ">=0.7,<0.8" },
     { name = "importlib", specifier = ">=1.0.4,<2" },
     { name = "jax", marker = "extra == 'fast'", specifier = ">=0.4" },
     { name = "jaxlib", marker = "extra == 'fast'", specifier = ">=0.4" },
@@ -1835,7 +1913,7 @@ dev = [
     { name = "pytest", specifier = ">=7.2,<9.0" },
     { name = "pytest-cov", specifier = ">=4,<6" },
     { name = "rich", specifier = ">=13,<15" },
-    { name = "ruff", specifier = ">=0.0.210,<0.9.3" },
+    { name = "ruff", specifier = ">=0.0.210,<0.15.21" },
     { name = "seaborn", specifier = ">=0.12,<0.14" },
     { name = "thermo", specifier = ">=0.2" },
     { name = "types-setuptools", specifier = ">=65,<76" },
@@ -2906,6 +2984,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Initial integration of the [Diffrax](https://docs.kidger.site/diffrax) solvers, mainly to add the [stiff solvers](https://docs.kidger.site/diffrax/examples/stiff_ode/) it provides.

The diffrax solver requires Jax, so the first question is, we now require Jax as a core feature or hide diffrax behind the `fast` feature flag?

In this initial implementation I've kept it behind the `fast` feature flag, but an option would be to replace the scipy solvers with the diffrax ones, as I think they are much more solid than the ones scipy exposes.

The only problem is that if someone wants to reproduce old simulated system this would be a bit of a breaking update, so I think it would be better to still keep the old solvers in the current proposed change? Open to feedback regarding this.

I haven't yet throughtly tested this in a "real world scenario", but the plan is to try to get some stiff system this week to compare the scipy solvers and the newly added Kvaerno solvers to see if they can handle it better.

I've also noted that I accidently linked the diffrax issue (#771) when doing the uv migration (which should have been #759, oopsie) instead of linking the correct issue. So if you want to re-open that one and close the uv issue...
